### PR TITLE
[WIP] Specify numbers for controls option

### DIFF
--- a/html5-youtube.js
+++ b/html5-youtube.js
@@ -201,8 +201,8 @@
 			throw new Error('`options.el` is require.');
 		}
 		var videoId = options.id || el.getAttribute('data-youtube-videoid');
-		var autoplay = this._getBooleanOption(options, 'autoplay', false);
-		var controls = this._getBooleanOption(options, 'controls', true);
+		var autoplay = this._getBooleanOption(options, 'autoplay', 0);
+		var controls = this._getBooleanOption(options, 'controls', 1);
 
 		var width;
 		var height = el.clientHeight;
@@ -245,6 +245,8 @@
 		else {
 			value = !!parseInt(value, 10);
 		}
+
+		value = (value ? 1 : 0);
 
 		return value;
 	};

--- a/test.js
+++ b/test.js
@@ -114,37 +114,37 @@ describe('Constructing', function() {
 			it('uses the value specified in options if specified on the element', function() {
 				elPlayer.setAttribute('data-youtube-controls', '0');
 				var videoOptions = player._getVideoOptions({ el:elPlayer, controls:true });
-				expect(videoOptions.playerVars.controls).toBe(true);
+				expect(videoOptions.playerVars.controls).toBe(1);
 			});
 
 			it('turns setting on if not specified', function() {
 				elPlayer.removeAttribute('data-youtube-controls');
 				var videoOptions = player._getVideoOptions({ el:elPlayer });
-				expect(videoOptions.playerVars.controls).toBe(true);
+				expect(videoOptions.playerVars.controls).toBe(1);
 			});
 
 			it('turns setting on if "1" is specified', function() {
 				elPlayer.setAttribute('data-youtube-controls', '1');
 				var videoOptions = player._getVideoOptions({ el:elPlayer });
-				expect(videoOptions.playerVars.controls).toBe(true);
+				expect(videoOptions.playerVars.controls).toBe(1);
 			});
 
 			it('turns setting on if invalid number like "-1" is specified', function() {
 				elPlayer.setAttribute('data-youtube-controls', '-1');
 				var videoOptions = player._getVideoOptions({ el:elPlayer });
-				expect(videoOptions.playerVars.controls).toBe(true);
+				expect(videoOptions.playerVars.controls).toBe(1);
 			});
 
 			it('turns setting off if "0" is specified', function() {
 				elPlayer.setAttribute('data-youtube-controls', '0');
 				var videoOptions = player._getVideoOptions({ el:elPlayer });
-				expect(videoOptions.playerVars.controls).toBe(false);
+				expect(videoOptions.playerVars.controls).toBe(0);
 			});
 
 			it('turns setting off if invalid string like "on" is specified', function() {
 				elPlayer.setAttribute('data-youtube-controls', 'on');
 				var videoOptions = player._getVideoOptions({ el:elPlayer });
-				expect(videoOptions.playerVars.controls).toBe(false);
+				expect(videoOptions.playerVars.controls).toBe(0);
 			});
 		});
 	});


### PR DESCRIPTION
#5
- These options should be accept both numbers (`0`, `1`, or `2`) and boolean.
- Boolean values `true` and `false` should be converted to `1` and `0` when passed to YT API.
